### PR TITLE
BasicRenderer: fixed warning message when resizing

### DIFF
--- a/src/renderer/BasicRenderer.h
+++ b/src/renderer/BasicRenderer.h
@@ -106,6 +106,7 @@ private:	// Members
 	// State
 	//----
 	static bool			frame_started;
+	static bool			frame_available;
 	static u32			current_image_index;
 
 	//----


### PR DESCRIPTION
This was due to the fact that when resizing, the next image from the swapchain wasn't available, which resulted in us not setting the frame_started variable to true. Now, frame_started switches to true at the start of frame_begin(), and a second variable is responsible for the image availableness.

If no next image was available, this is not an
error (the window is probably resizing), so we just early out of all render functions without outputting a warning.